### PR TITLE
Various fixes and enhancements for C++ libtrace

### DIFF
--- a/libtrace/src/readtrace.cpp
+++ b/libtrace/src/readtrace.cpp
@@ -18,6 +18,8 @@ void print_all(const char *f) {
 
   TraceContainerReader t(f);
 
+  std::cout << t.get_meta()->DebugString() << std::endl;
+
   while (!t.end_of_trace()) {
     ctr++;
     print(*(t.get_frame()));

--- a/libtrace/src/trace.container.cpp
+++ b/libtrace/src/trace.container.cpp
@@ -237,21 +237,15 @@ namespace SerializedTrace {
       throw (TraceException("Read zero-length frame at offset " + std::to_string(TELL(ifs))));
     }
 
-    /* We really just want a variable sized array, but MS VC++ doesn't support C99 yet.
-     *
-     * http://stackoverflow.com/questions/5246900/enabling-vlasvariable-length-arrays-in-ms-visual-c
-     */
-    auto_vec<char> buf ( new char[frame_len] );
+    std::vector<uint8_t> buf(frame_len);
 
     /* Read the frame into buf. */
-    if (fread(buf.get(), 1, frame_len, ifs) != frame_len) {
+    if (fread(buf.data(), 1, frame_len, ifs) != frame_len) {
       throw (TraceException("Unable to read frame from trace"));
     }
 
-    std::string sbuf(buf.get(), frame_len);
-
     std::unique_ptr<frame> f(new frame);
-    if (!(f->ParseFromString(sbuf))) {
+    if (!(f->ParseFromArray(buf.data(), buf.size()))) {
       throw (TraceException("Unable to parse from string"));
     }
     current_frame++;

--- a/libtrace/src/trace.container.cpp
+++ b/libtrace/src/trace.container.cpp
@@ -227,7 +227,7 @@ namespace SerializedTrace {
     }
   }
 
-  std::auto_ptr<frame> TraceContainerReader::get_frame(void) throw (TraceException) {
+  std::unique_ptr<frame> TraceContainerReader::get_frame(void) throw (TraceException) {
     /* Make sure we are in bounds. */
     check_end_of_trace("get_frame() on non-existant frame");
 
@@ -250,7 +250,7 @@ namespace SerializedTrace {
 
     std::string sbuf(buf.get(), frame_len);
 
-    std::auto_ptr<frame> f(new frame);
+    std::unique_ptr<frame> f(new frame);
     if (!(f->ParseFromString(sbuf))) {
       throw (TraceException("Unable to parse from string"));
     }
@@ -259,10 +259,10 @@ namespace SerializedTrace {
     return f;
   }
 
-  std::auto_ptr<std::vector<frame> > TraceContainerReader::get_frames(uint64_t requested_frames) throw (TraceException) {
+  std::unique_ptr<std::vector<frame> > TraceContainerReader::get_frames(uint64_t requested_frames) throw (TraceException) {
     check_end_of_trace("get_frames() on non-existant frame");
 
-    std::auto_ptr<std::vector<frame> > frames(new std::vector<frame>);
+    std::unique_ptr<std::vector<frame> > frames(new std::vector<frame>);
     for (uint64_t i = 0; i < requested_frames && current_frame < num_frames; i++) {
       frames->push_back(*(get_frame()));
     }

--- a/libtrace/src/trace.container.cpp
+++ b/libtrace/src/trace.container.cpp
@@ -12,12 +12,12 @@
 #ifdef _WIN32
 typedef uint64_t traceoff_t;
 #define SEEKNAME _fseeki64
-#define SEEK(f,x) { if (SEEKNAME(f, x, SEEK_SET) != 0) { throw (TraceException("Unable to seek in trace to offset " + x)); } }
+#define SEEK(f,x) { if (SEEKNAME(f, x, SEEK_SET) != 0) { throw (TraceException("Unable to seek in trace to offset " + std::to_string(x))); } }
 #define TELL(f) _ftelli64(f)
 #else
 typedef off_t traceoff_t;
 #define SEEKNAME fseeko
-#define SEEK(f,x) { if (SEEKNAME(f, x, SEEK_SET) != 0) { throw (TraceException("Unable to seek in trace to offset " + x)); } }
+#define SEEK(f,x) { if (SEEKNAME(f, x, SEEK_SET) != 0) { throw (TraceException("Unable to seek in trace to offset " + std::to_string(x))); } }
 #define TELL(f) ftello(f)
 #endif
 
@@ -222,7 +222,7 @@ namespace SerializedTrace {
     uint64_t frame_len;
     READ(frame_len);
     if (frame_len == 0) {
-      throw (TraceException("Read zero-length frame at offset " + TELL(ifs)));
+      throw (TraceException("Read zero-length frame at offset " + std::to_string(TELL(ifs))));
     }
 
     /* We really just want a variable sized array, but MS VC++ doesn't support C99 yet.

--- a/libtrace/src/trace.container.cpp
+++ b/libtrace/src/trace.container.cpp
@@ -46,7 +46,6 @@ namespace SerializedTrace {
                                              frame_architecture arch,
                                              uint64_t machine,
                                              uint64_t frames_per_toc_entry_in)
-    throw (TraceException)
     : num_frames (0)
     , frames_per_toc_entry (frames_per_toc_entry_in)
     , ofs(open_trace(filename,arch,machine,1LL)) {}
@@ -56,7 +55,6 @@ namespace SerializedTrace {
                                              frame_architecture arch,
                                              uint64_t machine,
                                              uint64_t frames_per_toc_entry_in)
-    throw (TraceException)
     : num_frames (0)
     , frames_per_toc_entry (frames_per_toc_entry_in)
     , ofs(open_trace(filename,arch,machine,2LL)) {
@@ -72,7 +70,7 @@ namespace SerializedTrace {
     }
   }
 
-  void TraceContainerWriter::add(const frame &f) throw (TraceException) {
+  void TraceContainerWriter::add(const frame &f) {
     if (num_frames > 0 && (num_frames % frames_per_toc_entry) == 0) {
       toc.push_back(TELL(ofs));
     }
@@ -111,7 +109,7 @@ namespace SerializedTrace {
     ofs = NULL;
   }
 
-  TraceContainerReader::TraceContainerReader(std::string filename) throw (TraceException)
+  TraceContainerReader::TraceContainerReader(std::string filename)
   {
     ifs = fopen(filename.c_str(), "rb");
     if (!ifs) { throw (TraceException("Unable to open trace for reading")); }
@@ -178,31 +176,31 @@ namespace SerializedTrace {
     seek(0);
   }
 
-  TraceContainerReader::~TraceContainerReader(void) throw () {
+  TraceContainerReader::~TraceContainerReader(void) noexcept {
     /* Nothing yet. */
   }
 
-  uint64_t TraceContainerReader::get_num_frames(void) throw () {
+  uint64_t TraceContainerReader::get_num_frames(void) noexcept {
     return num_frames;
   }
 
-  uint64_t TraceContainerReader::get_frames_per_toc_entry(void) throw () {
+  uint64_t TraceContainerReader::get_frames_per_toc_entry(void) noexcept {
     return frames_per_toc_entry;
   }
 
-  frame_architecture TraceContainerReader::get_arch(void) throw () {
+  frame_architecture TraceContainerReader::get_arch(void) noexcept {
     return arch;
   }
 
-  uint64_t TraceContainerReader::get_machine(void) throw () {
+  uint64_t TraceContainerReader::get_machine(void) noexcept {
     return mach;
   }
 
-  uint64_t TraceContainerReader::get_trace_version(void) throw () {
+  uint64_t TraceContainerReader::get_trace_version(void) noexcept {
     return trace_version;
   }
 
-  void TraceContainerReader::seek(uint64_t frame_number) throw (TraceException) {
+  void TraceContainerReader::seek(uint64_t frame_number) {
     /* First, make sure the frame is in range. */
     check_end_of_trace_num(frame_number, "seek() to non-existant frame");
 
@@ -227,7 +225,7 @@ namespace SerializedTrace {
     }
   }
 
-  std::unique_ptr<frame> TraceContainerReader::get_frame(void) throw (TraceException) {
+  std::unique_ptr<frame> TraceContainerReader::get_frame(void) {
     /* Make sure we are in bounds. */
     check_end_of_trace("get_frame() on non-existant frame");
 
@@ -253,7 +251,7 @@ namespace SerializedTrace {
     return f;
   }
 
-  std::unique_ptr<std::vector<frame> > TraceContainerReader::get_frames(uint64_t requested_frames) throw (TraceException) {
+  std::unique_ptr<std::vector<frame> > TraceContainerReader::get_frames(uint64_t requested_frames) {
     check_end_of_trace("get_frames() on non-existant frame");
 
     std::unique_ptr<std::vector<frame> > frames(new std::vector<frame>);
@@ -264,11 +262,11 @@ namespace SerializedTrace {
     return frames;
   }
 
-  bool TraceContainerReader::end_of_trace(void) throw () {
+  bool TraceContainerReader::end_of_trace(void) noexcept {
     return end_of_trace_num(current_frame);
   }
 
-  bool TraceContainerReader::end_of_trace_num(uint64_t frame_num) throw () {
+  bool TraceContainerReader::end_of_trace_num(uint64_t frame_num) noexcept {
     if (frame_num + 1 > num_frames) {
       return true;
     } else {
@@ -276,13 +274,13 @@ namespace SerializedTrace {
     }
   }
 
-  void TraceContainerReader::check_end_of_trace_num(uint64_t frame_num, std::string msg) throw (TraceException) {
+  void TraceContainerReader::check_end_of_trace_num(uint64_t frame_num, std::string msg) {
     if (end_of_trace_num(frame_num)) {
       throw (TraceException(msg));
     }
   }
 
-    void TraceContainerReader::check_end_of_trace(std::string msg) throw (TraceException) {
+    void TraceContainerReader::check_end_of_trace(std::string msg) {
       return check_end_of_trace_num(current_frame, msg);
     }
 };

--- a/libtrace/src/trace.container.cpp
+++ b/libtrace/src/trace.container.cpp
@@ -142,6 +142,18 @@ namespace SerializedTrace {
     uint64_t toc_offset;
     READ(toc_offset);
 
+    uint64_t meta_size;
+    READ(meta_size);
+    first_frame_offset = meta_offset + meta_size;
+
+    std::vector<uint8_t> meta_buf(meta_size);
+    if (fread(meta_buf.data(), 1, meta_buf.size(), ifs) != meta_buf.size()) {
+      throw (TraceException("Unable to read meta frame"));
+    }
+    if (!meta.ParseFromArray(meta_buf.data(), meta_buf.size())) {
+      throw (TraceException("Unable to parse meta frame"));
+    }
+
     /* Find the toc. */
     SEEK(ifs, toc_offset);
 

--- a/libtrace/src/trace.container.hpp
+++ b/libtrace/src/trace.container.hpp
@@ -23,6 +23,8 @@
  *  <uint64_t frame_machine, 0 for unspecified>
  *  <uint64_t n = number of trace frames>
  *  <uint64_t offset of field m (below)>
+ *  <uint64_t sizeof(meta frame)>
+ *  <meta frame>
  *  [ <uint64_t sizeof(trace frame 0)>
  *    <trace frame 0>
  *    ..............
@@ -61,9 +63,10 @@ namespace SerializedTrace {
   const uint64_t frame_machine_offset = 24LL;
   const uint64_t num_trace_frames_offset = 32LL;
   const uint64_t toc_offset_offset = 40LL;
-  const uint64_t first_frame_offset = 48LL;
+  const uint64_t meta_size_offset = 48LL;
+  const uint64_t meta_offset = 56LL;
 
-  const uint64_t lowest_supported_version = 1LL;
+  const uint64_t lowest_supported_version = 2LL;
   const uint64_t highest_supported_version = 2LL;
 
 
@@ -180,6 +183,8 @@ namespace SerializedTrace {
     /** Return true if frame pointer is at the end of the trace. */
     bool end_of_trace(void) throw ();
 
+    const meta_frame *get_meta(void) const { return &meta; }
+
   protected:
     /** File to read trace from. */
     FILE *ifs;
@@ -196,11 +201,16 @@ namespace SerializedTrace {
     /** Number of frames per toc entry. */
     uint64_t frames_per_toc_entry;
 
+    /** Base address in file where frames begin */
+    uint64_t first_frame_offset;
+
     /** CPU architecture. */
     frame_architecture arch;
 
     /** Machine type. */
     uint64_t mach;
+
+    meta_frame meta;
 
     /** Current frame number. */
     uint64_t current_frame;

--- a/libtrace/src/trace.container.hpp
+++ b/libtrace/src/trace.container.hpp
@@ -170,7 +170,7 @@ namespace SerializedTrace {
 
     /** Return the frame pointed to by the frame pointer. Advances the
         frame pointer by one after. */
-    std::auto_ptr<frame> get_frame(void) throw (TraceException);
+    std::unique_ptr<frame> get_frame(void) throw (TraceException);
 
     /** Return [num_frames] starting at the frame pointed to by the
         frame pointer. If there are not that many frames until the end
@@ -178,7 +178,7 @@ namespace SerializedTrace {
         frame pointer is set one frame after the last frame returned.
         If the last frame returned is the last frame in the trace, the
         frame pointer will point to an invalid frame. */
-    std::auto_ptr<std::vector<frame> > get_frames(uint64_t num_frames) throw (TraceException);
+    std::unique_ptr<std::vector<frame> > get_frames(uint64_t num_frames) throw (TraceException);
 
     /** Return true if frame pointer is at the end of the trace. */
     bool end_of_trace(void) throw ();

--- a/libtrace/src/trace.container.hpp
+++ b/libtrace/src/trace.container.hpp
@@ -78,9 +78,9 @@ namespace SerializedTrace {
         : msg (s)
         { }
 
-      ~TraceException(void) throw () { }
+      ~TraceException(void) noexcept { }
 
-      virtual const char* what() const throw()
+      virtual const char* what() const noexcept
         {
           return msg.c_str();
         }
@@ -100,19 +100,17 @@ namespace SerializedTrace {
     TraceContainerWriter(const std::string& filename,
                          frame_architecture arch = default_arch,
                          uint64_t machine = default_machine,
-                         uint64_t frames_per_toc_entry = default_frames_per_toc_entry)
-      throw (TraceException);
+                         uint64_t frames_per_toc_entry = default_frames_per_toc_entry);
 
     // creates a container for the second version of a protocol.
     TraceContainerWriter(const std::string& filename,
                          const meta_frame& meta,
                          frame_architecture arch = default_arch,
                          uint64_t machine = default_machine,
-                         uint64_t frames_per_toc_entry = default_frames_per_toc_entry)
-      throw (TraceException);
+                         uint64_t frames_per_toc_entry = default_frames_per_toc_entry);
 
     /** Add [frame] to the trace. */
-    void add(const frame &f) throw (TraceException);
+    void add(const frame &f);
 
     // closes the trace and underlying file stream. If the stream is
     // seekable, the output a table of contents and update the header
@@ -144,33 +142,33 @@ namespace SerializedTrace {
   public:
 
     /** Creates a trace container reader that reads from [filename]. */
-    TraceContainerReader(std::string filename) throw (TraceException);
+    TraceContainerReader(std::string filename);
 
     /** Destructor. */
-    ~TraceContainerReader(void) throw ();
+    ~TraceContainerReader(void) noexcept;
 
     /** Returns the number of frames in the trace. */
-    uint64_t get_num_frames(void) throw ();
+    uint64_t get_num_frames(void) noexcept;
 
     /** Returns the number of frames per toc entry. */
-    uint64_t get_frames_per_toc_entry(void) throw ();
+    uint64_t get_frames_per_toc_entry(void) noexcept;
 
     /** Returns the architecture of the trace. */
-    frame_architecture get_arch(void) throw ();
+    frame_architecture get_arch(void) noexcept;
 
     /** Returns the machine type (sub-architecture) of the trace. */
-    uint64_t get_machine(void) throw ();
+    uint64_t get_machine(void) noexcept;
 
     /** Returns trace version. */
-    uint64_t get_trace_version(void) throw ();
+    uint64_t get_trace_version(void) noexcept;
 
     /** Seek to frame number [frame_number]. The frame is numbered
      * 0. */
-    void seek(uint64_t frame_number) throw (TraceException);;
+    void seek(uint64_t frame_number);;
 
     /** Return the frame pointed to by the frame pointer. Advances the
         frame pointer by one after. */
-    std::unique_ptr<frame> get_frame(void) throw (TraceException);
+    std::unique_ptr<frame> get_frame(void);
 
     /** Return [num_frames] starting at the frame pointed to by the
         frame pointer. If there are not that many frames until the end
@@ -178,10 +176,10 @@ namespace SerializedTrace {
         frame pointer is set one frame after the last frame returned.
         If the last frame returned is the last frame in the trace, the
         frame pointer will point to an invalid frame. */
-    std::unique_ptr<std::vector<frame> > get_frames(uint64_t num_frames) throw (TraceException);
+    std::unique_ptr<std::vector<frame> > get_frames(uint64_t num_frames);
 
     /** Return true if frame pointer is at the end of the trace. */
-    bool end_of_trace(void) throw ();
+    bool end_of_trace(void) noexcept;
 
     const meta_frame *get_meta(void) const { return &meta; }
 
@@ -216,13 +214,13 @@ namespace SerializedTrace {
     uint64_t current_frame;
 
     /** Return true if [frame_num] is at the end of the trace. */
-    bool end_of_trace_num(uint64_t frame_num) throw ();
+    bool end_of_trace_num(uint64_t frame_num) noexcept;
 
     /** Raise exception if [frame_num] is at the end of the trace. */
-    void check_end_of_trace_num(uint64_t frame_num, std::string msg) throw (TraceException);
+    void check_end_of_trace_num(uint64_t frame_num, std::string msg);
 
     /** Raise exception if frame pointer is at the end of the trace. */
-    void check_end_of_trace(std::string msg) throw (TraceException);
+    void check_end_of_trace(std::string msg);
 
   };
 };

--- a/libtrace/src/trace.container.hpp
+++ b/libtrace/src/trace.container.hpp
@@ -225,18 +225,6 @@ namespace SerializedTrace {
     void check_end_of_trace(std::string msg) throw (TraceException);
 
   };
-
-  /* A minimal smart pointer class for arrays. */
-  template< typename T_ >
-  struct auto_vec{
-    T_* t_;
-    auto_vec( T_* t ): t_( t ) {}
-    ~auto_vec() { delete[] t_; }
-    T_* get() const { return t_; }
-    T_* operator->() const { return get(); }
-    T_& operator*() const { return *get(); }
-  };
-
 };
 
 #endif


### PR DESCRIPTION
With 349eede6b076c22da8caa3b4e89cb6c8806cfa59, the metaframe was introduced in `TraceContainerWriter` and the version bumped to 2, but `TraceContainerReader` was still assuming the old format, making it fail to read the files:
![Bildschirmfoto 2022-01-15 um 12 18 50](https://user-images.githubusercontent.com/1460997/149619838-3077860f-65d7-4173-9624-55675b55eead.png)
That is because it tried to parse a frame at the offset where the metaframe size is located now.

302ab735d344fecdb43f16b2ac02f273ad41520d fixes the reader and sets `lowest_supported_version` to 2 since the old format would not be parsed anymore. If desired, I can of course also make it support both, but I am not sure if it's worth adding additional complexity to the code for this.

The rest of the commits are minor fixes and enhancements along the way. See the individual commit descriptions for more info. If you want, I can of course also pull them apart into individual prs or remove some of them.