### PR TITLE
adds AArch64 support

### DIFF
--- a/lib/frame_arch.ml
+++ b/lib/frame_arch.ml
@@ -98,6 +98,7 @@ type t =
   | Lm32
   | Microblaze
   | M6502
+  | AArch64
   | Last
 [@@deriving enumerate, variants]
 

--- a/lib/frame_mach.ml
+++ b/lib/frame_mach.ml
@@ -90,3 +90,15 @@ module Sparc = struct
       let all = all
     end)
 end
+
+module AArch64 = struct
+  type t =
+    |  Unknown
+  [@@deriving enumerate, variants]
+
+  include Frame_enum.Make(struct
+      type nonrec t = t
+      let rank = Variants.to_rank
+      let all = all
+    end)
+end

--- a/lib/frame_reader.ml
+++ b/lib/frame_reader.ml
@@ -89,6 +89,10 @@ module Arch = struct
       | Some (X86_64 | X86_64_intel) -> Some `x86_64
       | _ -> None)
 
+  let aarch64 n = Frame_mach.AArch64.(match of_enum n with
+      | Some (Unknown) -> Some `aarch64
+      | _ -> None)
+
   (** a projection from BFD architectures to BAP.  *)
   let of_bfd arch mach = match arch with
     | Frame_arch.Arm -> arm mach
@@ -96,6 +100,7 @@ module Arch = struct
     | Frame_arch.Mips -> mips mach
     | Frame_arch.Powerpc -> ppc mach
     | Frame_arch.Sparc -> sparc mach
+    | Frame_arch.AArch64 -> aarch64 mach
     | _ -> None
 end
 

--- a/libtrace/src/frame_arch.h
+++ b/libtrace/src/frame_arch.h
@@ -382,6 +382,8 @@ enum frame_architecture
 #define frame_mach_lm32      1
   frame_arch_microblaze,/* Xilinx MicroBlaze. */
   frame_arch_6502,/* MOS Technology 6502. */
+  frame_arch_aarch64,   /* AArch64.  */
+#define frame_mach_aarch64 0
   frame_arch_last
   };
 


### PR DESCRIPTION
`frame_arch_aarch64`/`frame_mach_aarch64` is taken as-is from bfd, but added at the bottom to our enum.