### PR TITLE
fixes the missing piqi-generated file

### DIFF
--- a/libtrace/src/Makefile.am
+++ b/libtrace/src/Makefile.am
@@ -8,15 +8,17 @@ pkginclude_HEADERS = trace.container.hpp frame_arch.h frame.piqi.pb.h config.h
 PIQI = piqi
 PROTOC = protoc
 PIQIFILE = ../../piqi/frame.piqi
+PIQIFILEC = frame.piqi.pb.cc frame.piqi.pb.h
 
-frame.piqi.pb.cc frame.piqi.pb.h: frame.piqi.proto
+$(PIQIFILEC): frame.piqi.proto
 	$(PROTOC) $< --cpp_out=.
 
 frame.piqi.proto: $(PIQIFILE)
 	$(PIQI) to-proto $< -o $@
 
-libtrace_a_SOURCES = frame.piqi.pb.h frame.piqi.pb.cc trace.container.cpp
+BUILT_SOURCES = $(PIQIFILEC)
 
+libtrace_a_SOURCES = $(PIQIFILEC) trace.container.cpp
 utils_LDADD = libtrace.a -lprotobuf -lpthread
 
 bin_PROGRAMS = readtrace copytrace


### PR DESCRIPTION
Fixes #19. It turns out that if the executable built before the library the piqi sources are not generated and we have the error. The `BUILT_SOURCES` variable is the solution.